### PR TITLE
Set sort order of droplet list and bold IP address labels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.pythonPath": "venv/bin/python",
+    "python.linting.enabled": true
+}

--- a/app.py
+++ b/app.py
@@ -115,8 +115,11 @@ def index():
 
         do_droplets.append(droplet_info)
 
+    # Sort list based on droplet name
+    do_droplets_sorted = sorted(do_droplets, key = lambda i: i["name"])
+
     return render_template("index.html",
-                           droplet_info=do_droplets,
+                           droplet_info=do_droplets_sorted,
                            rendered_time=rendered_time)
 
 #endregion

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,15 +37,15 @@
             <td>{{ droplet.region_slug|upper }}</td>
             <td>
                 <ul>
-                    <li>IPv4 Public: {{ droplet.ipv4_public }}</li>
+                    <li><b>IPv4 Public:</b> {{ droplet.ipv4_public }}</li>
                     {% if droplet.ipv4_private %}
-                    <li>IPv4 Private: {{ droplet.ipv4_private }}</li>
+                    <li><b>IPv4 Private:</b> {{ droplet.ipv4_private }}</li>
                     {% endif %}
                     {% if droplet.ipv6_public %}
-                    <li>IPv6 Public: {{ droplet.ipv6_public }}</li>
+                    <li><b>IPv6 Public:</b> {{ droplet.ipv6_public }}</li>
                     {% endif %}
                     {% if droplet.ipv6_private %}
-                    <li>IPv6 Private: {{ droplet.ipv6_private }}</li>
+                    <li><b>IPv6 Private:</b> {{ droplet.ipv6_private }}</li>
                     {% endif %}
                 </ul>
             </td>


### PR DESCRIPTION
Use a lambda to sort the list of droplet dictionary objects by droplet name and bold the IPv4 and IPv6 address labels.

Also, set .vscode/settings.json with virtualenv Python path and Python linting.