### PR TITLE
Bump requests from 2.29.0 to 2.31.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ Flask==2.3.2
 python-dateutil==2.8.2
 pytz>=2023.3
 gunicorn==20.1.0
-requests==2.29.0
+requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==2.3.2
 python-dateutil==2.8.2
 pytz>=2023.3
 gunicorn==20.1.0
-requests==2.29.0
+requests==2.31.0


### PR DESCRIPTION
Upgrade `requests` dependency from 2.29.0 to 2.31.0 to resolve potential security vulnerabilities